### PR TITLE
SDK-6047: Final changes to plugin stub headers

### DIFF
--- a/plugins/dummy/include/dummy.h
+++ b/plugins/dummy/include/dummy.h
@@ -59,9 +59,12 @@ public:
 		return make_error_code(VideoSourceStatus::success);
 	}
 
-	[[nodiscard]] ImageView frame() noexcept override { return ImageView(metadata(), m_frame.get()); }
+	[[nodiscard]] ImageView frame() const noexcept override
+	{
+		return ImageView(metadata(), m_frame.get());
+	}
 
-	[[nodiscard]] ImageView frame(std::byte* data, std::size_t size) noexcept override;
+	[[nodiscard]] ImageView frame(std::byte* data, std::size_t size) const noexcept override;
 
 	std::error_code execute(const std::string& action) noexcept override;
 

--- a/plugins/dummy/include/dummy.h
+++ b/plugins/dummy/include/dummy.h
@@ -56,7 +56,7 @@ public:
 
 	[[nodiscard]] std::error_code nextFrame() noexcept override
 	{
-		return make_error_code(VideoSourceStatus::success);
+		return make_error_code(VideoSourceStatus::success());
 	}
 
 	[[nodiscard]] ImageView frame() const noexcept override

--- a/plugins/dummy/src/dummy.cpp
+++ b/plugins/dummy/src/dummy.cpp
@@ -47,14 +47,14 @@ initMe(NeuralaPluginManager* pluginManager, std::error_code* status)
 {
 	auto& pm = *dynamic_cast<neurala::PluginRegistrar*>(pluginManager);
 	*status = pm.registerPlugin<neurala::plug::dummy::Source>(kSourceTypeName, neurala::Version(1, 0));
-	if (*status != neurala::PluginStatus::success)
+	if (*status != neurala::PluginStatus::success())
 	{
 		return nullptr;
 	}
 
 	*status = pm.registerPlugin<neurala::plug::dummy::Discoverer>("dummyDiscoverer",
 	                                                              neurala::Version(1, 0));
-	if (*status != neurala::PluginStatus::success)
+	if (*status != neurala::PluginStatus::success())
 	{
 		return nullptr;
 	}

--- a/plugins/dummy/src/dummy.cpp
+++ b/plugins/dummy/src/dummy.cpp
@@ -112,7 +112,7 @@ Source::Source(const CameraInfo& cameraInfo, const Options& options)
 }
 
 ImageView
-Source::frame(std::byte* data, std::size_t size) noexcept
+Source::frame(std::byte* data, std::size_t size) const noexcept
 {
 	std::cout << "Copying frame to [" << data << "]\n";
 	std::copy_n(reinterpret_cast<const std::byte*>(frame().data()), frame().sizeBytes(), data);

--- a/plugins/empty/include/EmptyVideoSource.h
+++ b/plugins/empty/include/EmptyVideoSource.h
@@ -42,10 +42,10 @@ public:
 	[[nodiscard]] std::error_code nextFrame() noexcept final { return {}; }
 
 	// Get a frame from host memory, data needs to be valid until the end of processing​
-	[[nodiscard]] ImageView frame() noexcept final { return {}; }
+	[[nodiscard]] ImageView frame() const noexcept final { return {}; }
 
 	// Copy a frame into the buffer provided as argument
-	[[nodiscard]] ImageView frame(std::byte*, std::size_t) noexcept final { return {}; }
+	[[nodiscard]] ImageView frame(std::byte*, std::size_t) const noexcept final { return {}; }
 
 	// Executes an arbitrary action on the video source
 	[[nodiscard]] std::error_code execute(const std::string&) noexcept final { return {}; }

--- a/plugins/empty/src/initme.cpp
+++ b/plugins/empty/src/initme.cpp
@@ -33,19 +33,19 @@ initMe(NeuralaPluginManager* pluginManager, std::error_code* status)
 	auto& pm = *dynamic_cast<neurala::PluginRegistrar*>(pluginManager);
 	*status = pm.registerPlugin<neurala::plug::empty::CameraDiscoverer>("EmptyCameraDiscoverer",
 	                                                                    neurala::Version(1, 0));
-	if (*status != neurala::PluginStatus::success)
+	if (*status != neurala::PluginStatus::success())
 	{
 		return nullptr;
 	}
 	*status = pm.registerPlugin<neurala::plug::empty::VideoSource>("EmptyVideoSource",
 	                                                               neurala::Version(1, 0));
-	if (*status != neurala::PluginStatus::success)
+	if (*status != neurala::PluginStatus::success())
 	{
 		return nullptr;
 	}
 	*status = pm.registerPlugin<neurala::plug::empty::ResultsOutput>("EmptyResultsOutput",
 	                                                                 neurala::Version(1, 0));
-	if (*status != neurala::PluginStatus::success)
+	if (*status != neurala::PluginStatus::success())
 	{
 		return nullptr;
 	}

--- a/plugins/websocket/include/websocket/Input.h
+++ b/plugins/websocket/include/websocket/Input.h
@@ -81,10 +81,10 @@ public:
 	[[nodiscard]] std::error_code nextFrame() noexcept final;
 
 	// Get a frame from host memory, data needs to be valid until the end of processing​
-	[[nodiscard]] ImageView frame() noexcept final { return {cachedMetadata(), m_frame.data()}; }
+	[[nodiscard]] ImageView frame() const noexcept final { return {cachedMetadata(), m_frame.data()}; }
 
 	// Copy a frame into the buffer provided as argument
-	[[nodiscard]] ImageView frame(std::byte* data, std::size_t size) noexcept final;
+	[[nodiscard]] ImageView frame(std::byte* data, std::size_t size) const noexcept final;
 
 	// Executes an arbitrary action on the video source
 	[[nodiscard]] std::error_code execute(const std::string&) noexcept final { return {}; }

--- a/plugins/websocket/src/InitMe.cpp
+++ b/plugins/websocket/src/InitMe.cpp
@@ -33,17 +33,17 @@ initMe(NeuralaPluginManager* pluginManager, std::error_code* status)
 	using namespace neurala;
 	auto& pm = *dynamic_cast<PluginRegistrar*>(pluginManager);
 	*status = pm.registerPlugin<plug::ws::Discoverer>("websocketDiscoverer", Version(1, 0));
-	if (*status != PluginStatus::success)
+	if (*status != PluginStatus::success())
 	{
 		return nullptr;
 	}
 	*status = pm.registerPlugin<plug::ws::Input>("Input", Version(1, 0));
-	if (*status != PluginStatus::success)
+	if (*status != PluginStatus::success())
 	{
 		return nullptr;
 	}
 	*status = pm.registerPlugin<plug::ws::Output>("Output", Version(1, 0));
-	if (*status != PluginStatus::success)
+	if (*status != PluginStatus::success())
 	{
 		return nullptr;
 	}

--- a/plugins/websocket/src/Input.cpp
+++ b/plugins/websocket/src/Input.cpp
@@ -44,7 +44,7 @@ Input::nextFrame() noexcept
 }
 
 ImageView
-Input::frame(std::byte* data, std::size_t size) noexcept
+Input::frame(std::byte* data, std::size_t size) const noexcept
 {
 	const ImageMetadata& md = cachedMetadata();
 	if (size < md.sizeBytes())

--- a/plugins/websocket/src/Input.cpp
+++ b/plugins/websocket/src/Input.cpp
@@ -35,7 +35,7 @@ Input::nextFrame() noexcept
 		std::vector<std::byte> frameBuffer(cachedMetadata().sizeBytes());
 		m_client.frame(frameBuffer.data(), frameBuffer.size());
 		m_frame = std::move(frameBuffer);
-		return make_error_code(VideoSourceStatus::success);
+		return make_error_code(VideoSourceStatus::success());
 	}
 	catch (const beast::system_error& se)
 	{

--- a/stub/include/neurala/config/os.h
+++ b/stub/include/neurala/config/os.h
@@ -27,6 +27,11 @@
 #define NEURALA_OS_WINDOWS
 #endif
 
+#if !defined(NEURALA_OS_LINUX) \
+ && (defined(linux) || defined(__linux) || defined(__linux__) || defined(__gnu_linux))
+#define NEURALA_OS_LINUX
+#endif
+
 #if !defined(NEURALA_OS_APPLE) && defined(__APPLE__) /* Defined by Apple Clang for iOS and macOS \
                                                         both */
 #define NEURALA_OS_APPLE

--- a/stub/include/neurala/error/B4BError.h
+++ b/stub/include/neurala/error/B4BError.h
@@ -26,32 +26,19 @@
 
 namespace neurala
 {
-enum class B4BError : int
+struct B4BError final
 {
-	ok = 0,
-	unknown = 1,
-	notImplemented,
-	genericError,
-	invalidParameter,
-	unsupportedAction
-};
+	static constexpr B4BError ok() { return {0}; }
+	static constexpr B4BError unknown() { return {1}; }
+	static constexpr B4BError notImplemented() { return {2}; }
+	static constexpr B4BError genericError() { return {3}; }
+	static constexpr B4BError invalidParameter() { return {4}; }
+	static constexpr B4BError unsupportedAction() { return {5}; }
 
-// NOTE:20210927:jgerity:SWIG does not support `auto` without a trailing return type declaration (http://www.swig.org/Doc4.0/SWIGDocumentation.html#CPlusPlus11_alternate_function_syntax)
-#ifndef SWIG
-template<>
-class MetaEnum<B4BError> : public MetaEnumRegister<B4BError>
-{
-public:
-	static constexpr const auto values = enumRegisterValues(
-	 NEURALA_META_ENUM_ENTRY(B4BError, ok),
-	 NEURALA_META_ENUM_ENTRY(B4BError, unknown),
-	 NEURALA_META_ENUM_ENTRY(B4BError, notImplemented),
-	 NEURALA_META_ENUM_ENTRY(B4BError, genericError),
-	 NEURALA_META_ENUM_ENTRY(B4BError, invalidParameter),
-	 NEURALA_META_ENUM_ENTRY(B4BError, unsupportedAction));
-	static constexpr const auto fallbackValue = values[1];
+	constexpr operator int() const noexcept { return m_value; }
+
+	int m_value;
 };
-#endif // SWIG
 
 NEURALA_PUBLIC const std::error_category& b4bCategory() noexcept;
 

--- a/stub/include/neurala/plugin/PluginErrorCallback.h
+++ b/stub/include/neurala/plugin/PluginErrorCallback.h
@@ -30,7 +30,7 @@ namespace neurala
  */
 class PluginErrorCallback
 {
-	std::error_code m_code{B4BError::ok};
+	std::error_code m_code{B4BError::ok()};
 	std::string m_exception;
 
 public:
@@ -38,7 +38,7 @@ public:
 	{
 		try
 		{
-			m_code = B4BError::genericError;
+			m_code = B4BError::genericError();
 			m_exception = s;
 		}
 		catch (...)

--- a/stub/include/neurala/plugin/PluginStatus.h
+++ b/stub/include/neurala/plugin/PluginStatus.h
@@ -29,13 +29,17 @@ namespace neurala
 /**
  * @brief Plugin status codes.
  */
-enum class PluginStatus
+struct PluginStatus final
 {
-	success,
-	unknown,
-	wrongVersion,
-	invalidName,
-	alreadyRegistered
+	static constexpr PluginStatus success() { return {0}; }
+	static constexpr PluginStatus unknown() { return {1}; }
+	static constexpr PluginStatus wrongVersion() { return {2}; }
+	static constexpr PluginStatus invalidName() { return {3}; }
+	static constexpr PluginStatus alreadyRegistered() { return {4}; }
+
+	constexpr operator int() const noexcept { return m_value; }
+
+	int m_value;
 };
 
 /// @brief Definition of the plugin status error domain

--- a/stub/include/neurala/utils/ResultsOutput.h
+++ b/stub/include/neurala/utils/ResultsOutput.h
@@ -30,12 +30,13 @@
 namespace neurala
 {
 /**
- * @brief A type representing the status of a pipeline job upon
- *        stopping.
+ * @brief A type representing the status of a pipeline job upon stopping.
  */
 struct ResultsOutputStatus final
 {
+	///< Indicates that the pipeline job has terminated normally.
 	static constexpr ResultsOutputStatus stopped() { return {0}; }
+	///< Indicates that the pipeline job has terminated abnormally.
 	static constexpr ResultsOutputStatus faulted() { return {1}; }
 
 	constexpr operator int() const noexcept { return m_value; }

--- a/stub/include/neurala/utils/ResultsOutput.h
+++ b/stub/include/neurala/utils/ResultsOutput.h
@@ -30,13 +30,17 @@
 namespace neurala
 {
 /**
- * @brief An enumeration type representing the status of a pipeline job upon
+ * @brief A type representing the status of a pipeline job upon
  *        stopping.
  */
-enum class EResultsOutputStatus
+struct ResultsOutputStatus final
 {
-	stopped, ///< Indicates that the pipeline job has terminated normally.
-	faulted  ///< Indicates that the pipeline job has terminated abnormally.
+	static constexpr ResultsOutputStatus stopped() { return {0}; }
+	static constexpr ResultsOutputStatus faulted() { return {1}; }
+
+	constexpr operator int() const noexcept { return m_value; }
+
+	int m_value;
 };
 
 /**
@@ -63,7 +67,7 @@ public:
 	 *           used as a discriminator to track which job is stopping.
 	 * @param status The reason for stopping.
 	 */
-	virtual void onStop(std::string_view id, EResultsOutputStatus status) noexcept { }
+	virtual void onStop(std::string_view id, ResultsOutputStatus status) noexcept { }
 };
 
 /**

--- a/stub/include/neurala/video/VideoSource.h
+++ b/stub/include/neurala/video/VideoSource.h
@@ -76,7 +76,7 @@ public:
 	 * Repetition in metadata requests between the dedicated function and as part of the ImageView's is
 	 * intentional. Provided there are no frame to frame changes, the returned data should be the same.
 	 */
-	[[nodiscard]] virtual ImageView frame() noexcept = 0;
+	[[nodiscard]] virtual ImageView frame() const noexcept = 0;
 
 	/**
 	 * @brief Copy a frame into the buffer provided as argument
@@ -87,7 +87,7 @@ public:
 	 * @param data address of the provided buffer
 	 * @param capacity size limit of the provided buffer, expressed in bytes
 	 */
-	[[nodiscard]] virtual ImageView frame(std::byte* data, std::size_t capacity) noexcept = 0;
+	[[nodiscard]] virtual ImageView frame(std::byte* data, std::size_t capacity) const noexcept = 0;
 
 	// Executes an arbitrary action on the video source
 	[[nodiscard]] virtual std::error_code execute(const std::string& action) noexcept = 0;

--- a/stub/include/neurala/video/VideoSourceStatus.h
+++ b/stub/include/neurala/video/VideoSourceStatus.h
@@ -29,59 +29,45 @@
 namespace neurala
 {
 /**
- * @brief Enum that describes the status of a VideoSource
+ * @brief Type that describes the status of a VideoSource
  */
-enum class VideoSourceStatus
+struct VideoSourceStatus final
 {
 	/// Operation was successful.
-	success,
+	static constexpr VideoSourceStatus success() { return {0}; }
 	/// Fetching frames timed out.  This is considered an error.
-	timeout,
+	static constexpr VideoSourceStatus timeout() { return {1}; }
 	/*
 	 * Internal buffer overflow (e.g. frames not fetched in time).
 	 * Currently buffered frames may still be fetched, however,
 	 * so this may or may not be an error condition depending on
 	 * whether skipped frames are allowed.
 	 */
-	overflow,
+	static constexpr VideoSourceStatus overflow() { return {2}; }
 	/*
 	 * All other errors.  (E.x. Requested frame number is outside valid range, no frame data
 	 * available, VideoInput connection was closed...)
 	 */
-	error,
+	static constexpr VideoSourceStatus error() { return {3}; }
 	/// Input format is not understood by the converters
-	pixelFormatNotSupported,
+	static constexpr VideoSourceStatus pixelFormatNotSupported() { return {4}; }
 	/// Information provided is not correct
-	invalidParameter,
+	static constexpr VideoSourceStatus invalidParameter() { return {5}; }
 	/// Functionality is not implemented
-	notImplemented,
+	static constexpr VideoSourceStatus notImplemented() { return {6}; }
 	/// Functionality not supported
-	unsupportedAction,
+	static constexpr VideoSourceStatus unsupportedAction() { return {7}; }
 	/// Unknown state.
-	unknown
+	static constexpr VideoSourceStatus unknown() { return {8}; }
+
+	constexpr operator int() const noexcept { return m_value; }
+
+	int m_value;
 };
 
 NEURALA_PUBLIC const std::error_category& videoSourceStatusCategory() noexcept;
 NEURALA_PUBLIC std::error_code make_error_code(VideoSourceStatus res) noexcept;
 NEURALA_PUBLIC std::error_condition make_error_condition(VideoSourceStatus res) noexcept;
-
-template<>
-class MetaEnum<VideoSourceStatus> : public MetaEnumRegister<VideoSourceStatus>
-{
-public:
-	static constexpr const auto values = enumRegisterValues(
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, success),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, timeout),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, overflow),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, error),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, pixelFormatNotSupported),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, invalidParameter),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, notImplemented),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, unsupportedAction),
-	 NEURALA_META_ENUM_ENTRY(VideoSourceStatus, unknown));
-
-	static constexpr const auto fallbackValue = values[0];
-};
 
 } // namespace neurala
 

--- a/stub/include/neurala/video/VideoSourceStatus.h
+++ b/stub/include/neurala/video/VideoSourceStatus.h
@@ -35,30 +35,30 @@ struct VideoSourceStatus final
 {
 	/// Operation was successful.
 	static constexpr VideoSourceStatus success() { return {0}; }
-	/// Fetching frames timed out.  This is considered an error.
-	static constexpr VideoSourceStatus timeout() { return {1}; }
+	/// Unknown state.
+	static constexpr VideoSourceStatus unknown() { return {1}; }
+	/// Fetching frames timed out. This is considered an error.
+	static constexpr VideoSourceStatus timeout() { return {2}; }
 	/*
 	 * Internal buffer overflow (e.g. frames not fetched in time).
 	 * Currently buffered frames may still be fetched, however,
 	 * so this may or may not be an error condition depending on
 	 * whether skipped frames are allowed.
 	 */
-	static constexpr VideoSourceStatus overflow() { return {2}; }
+	static constexpr VideoSourceStatus overflow() { return {3}; }
 	/*
-	 * All other errors.  (E.x. Requested frame number is outside valid range, no frame data
-	 * available, VideoInput connection was closed...)
+	 * All other errors (requested frame number is outside valid range, no frame data
+	 * available, VideoInput connection was closed, etc.).
 	 */
-	static constexpr VideoSourceStatus error() { return {3}; }
-	/// Input format is not understood by the converters
-	static constexpr VideoSourceStatus pixelFormatNotSupported() { return {4}; }
-	/// Information provided is not correct
-	static constexpr VideoSourceStatus invalidParameter() { return {5}; }
-	/// Functionality is not implemented
-	static constexpr VideoSourceStatus notImplemented() { return {6}; }
-	/// Functionality not supported
-	static constexpr VideoSourceStatus unsupportedAction() { return {7}; }
-	/// Unknown state.
-	static constexpr VideoSourceStatus unknown() { return {8}; }
+	static constexpr VideoSourceStatus error() { return {4}; }
+	/// Input format is not understood by the converters.
+	static constexpr VideoSourceStatus pixelFormatNotSupported() { return {5}; }
+	/// Information provided is not correct.
+	static constexpr VideoSourceStatus invalidParameter() { return {6}; }
+	/// Functionality is not implemented.
+	static constexpr VideoSourceStatus notImplemented() { return {7}; }
+	/// Functionality not supported.
+	static constexpr VideoSourceStatus unsupportedAction() { return {8}; }
 
 	constexpr operator int() const noexcept { return m_value; }
 

--- a/stub/src/B4BError.cpp
+++ b/stub/src/B4BError.cpp
@@ -28,8 +28,22 @@ public:
 	virtual const char* name() const noexcept { return "b4b_error"; }
 	virtual std::string message(int ev) const noexcept
 	{
-		const auto code = static_cast<B4BError>(ev);
-		return enumToString(code);
+		switch (ev)
+		{
+			case B4BError::ok():
+				return "ok";
+			case B4BError::notImplemented():
+				return "notImplemented";
+			case B4BError::genericError():
+				return "genericError";
+			case B4BError::invalidParameter():
+				return "invalidParameter";
+			case B4BError::unsupportedAction():
+				return "unsupportedAction";
+			case B4BError::unknown():
+			default:
+				return "unknown";
+		}
 	}
 };
 } // namespace

--- a/stub/src/PluginManager.cpp
+++ b/stub/src/PluginManager.cpp
@@ -53,13 +53,13 @@ registerClass(const char* name,
 		    }))
 		{
 			// empty name or name with anything except [a-zA-Z0-9\_] is not allowed
-			return make_error_code(PluginStatus::invalidName);
+			return make_error_code(PluginStatus::invalidName());
 		}
 
 		if (m_version.major() != version.major())
 		{
 			// plugin and host versions mismatch
-			return make_error_code(PluginStatus::wrongVersion);
+			return make_error_code(PluginStatus::wrongVersion());
 		}
 
 		std::lock_guard<std::mutex> lock{m_classesMutex};
@@ -68,16 +68,16 @@ registerClass(const char* name,
 		if (!it.second)
 		{
 			// class already registered
-			return make_error_code(PluginStatus::alreadyRegistered);
+			return make_error_code(PluginStatus::alreadyRegistered());
 		}
 	}
 	catch (...)
 	{
 		// unknown error - most likely memory allocation error
-		return make_error_code(PluginStatus::unknown);
+		return make_error_code(PluginStatus::unknown());
 	}
 
-	return make_error_code(PluginStatus::success);
+	return make_error_code(PluginStatus::success());
 }
 
 } // namespace neurala

--- a/stub/src/PluginStatus.cpp
+++ b/stub/src/PluginStatus.cpp
@@ -30,14 +30,15 @@ pluginStatusToStr(neurala::PluginStatus status)
 {
 	switch (status)
 	{
-		case neurala::PluginStatus::success:
+		case neurala::PluginStatus::success():
 			return "success";
-		case neurala::PluginStatus::wrongVersion:
+		case neurala::PluginStatus::wrongVersion():
 			return "incompatible version";
-		case neurala::PluginStatus::invalidName:
+		case neurala::PluginStatus::invalidName():
 			return "invalid name";
-		case neurala::PluginStatus::alreadyRegistered:
+		case neurala::PluginStatus::alreadyRegistered():
 			return "already registered";
+		case neurala::PluginStatus::unknown():
 		default:
 			return "unknown";
 	}
@@ -48,10 +49,7 @@ class PluginStatusCategory : public std::error_category
 public:
 	const char* name() const noexcept override { return "neurala::PluginStatus"; }
 
-	std::string message(int c) const override
-	{
-		return pluginStatusToStr(static_cast<neurala::PluginStatus>(c));
-	}
+	std::string message(int c) const override { return pluginStatusToStr({c}); }
 
 	bool equivalent(int code, const std::error_condition& condition) const noexcept override
 	{
@@ -61,15 +59,14 @@ public:
 			return code == condition.value();
 		}
 
-		switch (static_cast<neurala::PluginStatus>(code))
+		switch (code)
 		{
-			case neurala::PluginStatus::success:
+			case neurala::PluginStatus::success():
 				return neurala::B4BError::ok() == condition;
-
-			case neurala::PluginStatus::wrongVersion:
-			case neurala::PluginStatus::invalidName:
+			case neurala::PluginStatus::wrongVersion():
+			case neurala::PluginStatus::invalidName():
 				return neurala::B4BError::genericError() == condition;
-			case neurala::PluginStatus::unknown:
+			case neurala::PluginStatus::unknown():
 				return neurala::B4BError::unknown() == condition;
 			default:
 				return false;
@@ -84,14 +81,14 @@ public:
 			return code.value() == condition;
 		}
 
-		switch (static_cast<neurala::PluginStatus>(condition))
+		switch (condition)
 		{
-			case neurala::PluginStatus::success:
+			case neurala::PluginStatus::success():
 				return code == neurala::B4BError::ok();
-			case neurala::PluginStatus::wrongVersion:
-			case neurala::PluginStatus::invalidName:
+			case neurala::PluginStatus::wrongVersion():
+			case neurala::PluginStatus::invalidName():
 				return code == neurala::B4BError::genericError();
-			case neurala::PluginStatus::unknown:
+			case neurala::PluginStatus::unknown():
 				return code == neurala::B4BError::unknown();
 			default:
 				return false;

--- a/stub/src/PluginStatus.cpp
+++ b/stub/src/PluginStatus.cpp
@@ -64,13 +64,13 @@ public:
 		switch (static_cast<neurala::PluginStatus>(code))
 		{
 			case neurala::PluginStatus::success:
-				return neurala::B4BError::ok == condition;
+				return neurala::B4BError::ok() == condition;
 
 			case neurala::PluginStatus::wrongVersion:
 			case neurala::PluginStatus::invalidName:
-				return neurala::B4BError::genericError == condition;
+				return neurala::B4BError::genericError() == condition;
 			case neurala::PluginStatus::unknown:
-				return neurala::B4BError::unknown == condition;
+				return neurala::B4BError::unknown() == condition;
 			default:
 				return false;
 		}
@@ -87,12 +87,12 @@ public:
 		switch (static_cast<neurala::PluginStatus>(condition))
 		{
 			case neurala::PluginStatus::success:
-				return code == neurala::B4BError::ok;
+				return code == neurala::B4BError::ok();
 			case neurala::PluginStatus::wrongVersion:
 			case neurala::PluginStatus::invalidName:
-				return code == neurala::B4BError::genericError;
+				return code == neurala::B4BError::genericError();
 			case neurala::PluginStatus::unknown:
-				return code == neurala::B4BError::unknown;
+				return code == neurala::B4BError::unknown();
 			default:
 				return false;
 		}

--- a/stub/src/VideoSourceStatus.cpp
+++ b/stub/src/VideoSourceStatus.cpp
@@ -31,7 +31,28 @@ public:
 
 	std::string message(int c) const override
 	{
-		return enumToString(static_cast<VideoSourceStatus>(c));
+		switch (c)
+		{
+			case VideoSourceStatus::success():
+				return "success";
+			case VideoSourceStatus::timeout():
+				return "timeout";
+			case VideoSourceStatus::overflow():
+				return "overflow";
+			case VideoSourceStatus::error():
+				return "error";
+			case VideoSourceStatus::pixelFormatNotSupported():
+				return "pixelFormatNotSupported";
+			case VideoSourceStatus::invalidParameter():
+				return "invalidParameter";
+			case VideoSourceStatus::notImplemented():
+				return "notImplemented";
+			case VideoSourceStatus::unsupportedAction():
+				return "unsupportedAction";
+			case VideoSourceStatus::unknown():
+			default:
+				return "unknown";
+		}
 	}
 
 	bool equivalent(int code, const std::error_condition& condition) const noexcept override
@@ -42,13 +63,13 @@ public:
 			return code == condition.value();
 		}
 
-		switch (static_cast<VideoSourceStatus>(code))
+		switch (code)
 		{
-			case VideoSourceStatus::success:
+			case VideoSourceStatus::success():
 				return B4BError::ok == condition;
-			case VideoSourceStatus::error:
+			case VideoSourceStatus::error():
 				return B4BError::genericError == condition;
-			case VideoSourceStatus::unknown:
+			case VideoSourceStatus::unknown():
 				return B4BError::unknown == condition;
 			default:
 				return false;
@@ -63,13 +84,13 @@ public:
 			return code.value() == condition;
 		}
 
-		switch (static_cast<VideoSourceStatus>(condition))
+		switch (condition)
 		{
-			case VideoSourceStatus::success:
+			case VideoSourceStatus::success():
 				return code == B4BError::ok;
-			case VideoSourceStatus::error:
+			case VideoSourceStatus::error():
 				return code == B4BError::genericError;
-			case VideoSourceStatus::unknown:
+			case VideoSourceStatus::unknown():
 				return code == B4BError::unknown;
 			default:
 				return false;

--- a/stub/src/VideoSourceStatus.cpp
+++ b/stub/src/VideoSourceStatus.cpp
@@ -66,11 +66,11 @@ public:
 		switch (code)
 		{
 			case VideoSourceStatus::success():
-				return B4BError::ok == condition;
+				return B4BError::ok() == condition;
 			case VideoSourceStatus::error():
-				return B4BError::genericError == condition;
+				return B4BError::genericError() == condition;
 			case VideoSourceStatus::unknown():
-				return B4BError::unknown == condition;
+				return B4BError::unknown() == condition;
 			default:
 				return false;
 		}
@@ -87,11 +87,11 @@ public:
 		switch (condition)
 		{
 			case VideoSourceStatus::success():
-				return code == B4BError::ok;
+				return code == B4BError::ok();
 			case VideoSourceStatus::error():
-				return code == B4BError::genericError;
+				return code == B4BError::genericError();
 			case VideoSourceStatus::unknown():
-				return code == B4BError::unknown;
+				return code == B4BError::unknown();
 			default:
 				return false;
 		}


### PR DESCRIPTION
**JIRA**: https://neurala.atlassian.net/browse/SDK-6047

Changelog
------------------

- marked both `VideoSource::frame` overloads `const`
- added `NEURALA_OS_LINUX` macro
- defined `ResultsOutputStatus`, `VideoSourceStatus`, `B4BError`, and `PluginStatus` as POD integer wrappers

Reviewer Checklist
------------------

> Should be edited by reviewers only

- [ ] Does this implement the story reqs?
- [ ] Does this match the [coding standard](../wiki/C-Based-Languages-Style-Guide)?
	- [ ] Are all TODO's in the [proper format](../wiki/C-Based-Languages-Style-Guide#commenting)?
	- [ ] Have JIRA tickets been made for all TODO's?
- [ ] Does this include tests that exercise the altered/added code?
- [ ] If it modifies a public API, is the documentation updated?