### PR TITLE
SDK-6135: Disable exporting all library symbols by default on Windows

### DIFF
--- a/stub/include/neurala/cppcompat/typetraits.h
+++ b/stub/include/neurala/cppcompat/typetraits.h
@@ -24,12 +24,14 @@
 #include <functional>
 #include <type_traits>
 
+#include "neurala/exports.h"
+
 namespace std17
 {
 namespace detail
 {
 template<class... Ts>
-struct makeVoid
+struct NEURALA_PUBLIC makeVoid
 {
 	using type = void;
 };
@@ -45,15 +47,16 @@ using void_t = typename detail::makeVoid<Ts...>::type;
  * Backported implementation from C++17.
  */
 template<class... Ts>
-struct conjunction : std::true_type
+struct NEURALA_PUBLIC conjunction : std::true_type
 { };
 
 template<class T>
-struct conjunction<T> : public T
+struct NEURALA_PUBLIC conjunction<T> : public T
 { };
 
 template<class T, class... Ts>
-struct conjunction<T, Ts...> : public std::conditional<bool(T::value), conjunction<Ts...>, T>::type
+struct NEURALA_PUBLIC conjunction<T, Ts...>
+ : public std::conditional<bool(T::value), conjunction<Ts...>, T>::type
 { };
 
 /**
@@ -62,15 +65,16 @@ struct conjunction<T, Ts...> : public std::conditional<bool(T::value), conjuncti
  * Backported implementation from C++17.
  */
 template<class... Ts>
-struct disjunction : public std::false_type
+struct NEURALA_PUBLIC disjunction : public std::false_type
 { };
 
 template<class T>
-struct disjunction<T> : public T
+struct NEURALA_PUBLIC disjunction<T> : public T
 { };
 
 template<class T, class... Ts>
-struct disjunction<T, Ts...> : public std::conditional<bool(T::value), T, disjunction<Ts...>>::type
+struct NEURALA_PUBLIC disjunction<T, Ts...>
+ : public std::conditional<bool(T::value), T, disjunction<Ts...>>::type
 { };
 
 /**
@@ -79,7 +83,7 @@ struct disjunction<T, Ts...> : public std::conditional<bool(T::value), T, disjun
  * Backported implementation from C++17.
  */
 template<class F, class... Args>
-struct is_invocable
+struct NEURALA_PUBLIC is_invocable
  : std::is_constructible<std::function<void(Args...)>,
                          std::reference_wrapper<typename std::remove_reference<F>::type>>
 { };
@@ -89,7 +93,7 @@ struct is_invocable
  * is convertible to @p R.
  */
 template<class R, class F, class... Args>
-struct is_invocable_r
+struct NEURALA_PUBLIC is_invocable_r
  : std::is_constructible<std::function<R(Args...)>,
                          std::reference_wrapper<typename std::remove_reference<F>::type>>
 { };

--- a/stub/include/neurala/cppcompat/typetraits.h
+++ b/stub/include/neurala/cppcompat/typetraits.h
@@ -31,7 +31,7 @@ namespace std17
 namespace detail
 {
 template<class... Ts>
-struct NEURALA_PUBLIC makeVoid
+struct makeVoid
 {
 	using type = void;
 };
@@ -47,16 +47,15 @@ using void_t = typename detail::makeVoid<Ts...>::type;
  * Backported implementation from C++17.
  */
 template<class... Ts>
-struct NEURALA_PUBLIC conjunction : std::true_type
+struct conjunction : std::true_type
 { };
 
 template<class T>
-struct NEURALA_PUBLIC conjunction<T> : public T
+struct conjunction<T> : public T
 { };
 
 template<class T, class... Ts>
-struct NEURALA_PUBLIC conjunction<T, Ts...>
- : public std::conditional<bool(T::value), conjunction<Ts...>, T>::type
+struct conjunction<T, Ts...> : public std::conditional<bool(T::value), conjunction<Ts...>, T>::type
 { };
 
 /**
@@ -65,16 +64,15 @@ struct NEURALA_PUBLIC conjunction<T, Ts...>
  * Backported implementation from C++17.
  */
 template<class... Ts>
-struct NEURALA_PUBLIC disjunction : public std::false_type
+struct disjunction : public std::false_type
 { };
 
 template<class T>
-struct NEURALA_PUBLIC disjunction<T> : public T
+struct disjunction<T> : public T
 { };
 
 template<class T, class... Ts>
-struct NEURALA_PUBLIC disjunction<T, Ts...>
- : public std::conditional<bool(T::value), T, disjunction<Ts...>>::type
+struct disjunction<T, Ts...> : public std::conditional<bool(T::value), T, disjunction<Ts...>>::type
 { };
 
 /**
@@ -83,7 +81,7 @@ struct NEURALA_PUBLIC disjunction<T, Ts...>
  * Backported implementation from C++17.
  */
 template<class F, class... Args>
-struct NEURALA_PUBLIC is_invocable
+struct is_invocable
  : std::is_constructible<std::function<void(Args...)>,
                          std::reference_wrapper<typename std::remove_reference<F>::type>>
 { };
@@ -93,7 +91,7 @@ struct NEURALA_PUBLIC is_invocable
  * is convertible to @p R.
  */
 template<class R, class F, class... Args>
-struct NEURALA_PUBLIC is_invocable_r
+struct is_invocable_r
  : std::is_constructible<std::function<R(Args...)>,
                          std::reference_wrapper<typename std::remove_reference<F>::type>>
 { };

--- a/stub/include/neurala/error/B4BError.h
+++ b/stub/include/neurala/error/B4BError.h
@@ -60,7 +60,7 @@ NEURALA_PUBLIC std::error_condition make_error_condition(B4BError error) noexcep
 namespace std
 {
 template<>
-struct NEURALA_PUBLIC is_error_code_enum<neurala::B4BError> : public true_type
+struct is_error_code_enum<neurala::B4BError> : public true_type
 { };
 } // namespace std
 

--- a/stub/include/neurala/error/B4BError.h
+++ b/stub/include/neurala/error/B4BError.h
@@ -25,10 +25,10 @@
 
 namespace neurala
 {
-struct B4BError
+struct NEURALA_PUBLIC B4BError
 // NOTE:20211227:jgerity:SWIG does not support the final keyword in class declarations, see SDK-6067
 #ifndef SWIG
-final
+ final
 #endif // SWIG
 {
 	static constexpr B4BError ok() { return {0}; }
@@ -60,7 +60,7 @@ NEURALA_PUBLIC std::error_condition make_error_condition(B4BError error) noexcep
 namespace std
 {
 template<>
-struct is_error_code_enum<neurala::B4BError> : public true_type
+struct NEURALA_PUBLIC is_error_code_enum<neurala::B4BError> : public true_type
 { };
 } // namespace std
 

--- a/stub/include/neurala/meta/detail/typeName.h
+++ b/stub/include/neurala/meta/detail/typeName.h
@@ -24,6 +24,8 @@
 #include <ostream>
 #include <stdexcept>
 
+#include "neurala/exports.h"
+
 namespace neurala
 {
 /**
@@ -32,7 +34,7 @@ namespace neurala
  * @warning This is not a null-terminated string, so @ref size() is the only function that
  *          can convey it's length properly.
  */
-class StaticString
+class NEURALA_PUBLIC StaticString
 {
 public:
 	using value_type = char;
@@ -103,7 +105,7 @@ public:
 	}
 };
 
-inline std::ostream&
+inline NEURALA_PUBLIC std::ostream&
 operator<<(std::ostream& os, const StaticString& s)
 {
 	return os.write(s.data(), s.size());

--- a/stub/include/neurala/plugin/PluginArguments.h
+++ b/stub/include/neurala/plugin/PluginArguments.h
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "neurala/exports.h"
 #include "neurala/utils/detail/AnyRef.h"
 
 namespace neurala
@@ -32,7 +33,7 @@ namespace neurala
  * It type erases all arguments passed to it, but performs type checking at retrieval to avoid
  * incorrect casts.
  */
-class PluginArguments
+class NEURALA_PUBLIC PluginArguments
 {
 	std::vector<AnyRef> m_args;
 

--- a/stub/include/neurala/plugin/PluginErrorCallback.h
+++ b/stub/include/neurala/plugin/PluginErrorCallback.h
@@ -22,13 +22,14 @@
 #include <string>
 
 #include "neurala/error/B4BError.h"
+#include "neurala/exports.h"
 
 namespace neurala
 {
 /**
  * @brief Utility class to transport exception messages between @ref PluginManager and plugins.
  */
-class PluginErrorCallback
+class NEURALA_PUBLIC PluginErrorCallback
 {
 	std::error_code m_code{B4BError::ok()};
 	std::string m_exception;

--- a/stub/include/neurala/plugin/PluginStatus.h
+++ b/stub/include/neurala/plugin/PluginStatus.h
@@ -29,7 +29,7 @@ namespace neurala
 /**
  * @brief Plugin status codes.
  */
-struct PluginStatus final
+struct NEURALA_PUBLIC PluginStatus final
 {
 	static constexpr PluginStatus success() { return {0}; }
 	static constexpr PluginStatus unknown() { return {1}; }
@@ -66,7 +66,7 @@ NEURALA_PUBLIC std::error_code make_error_code(PluginStatus status) noexcept; //
 namespace std
 {
 template<>
-struct is_error_condition_enum<neurala::PluginStatus> : true_type
+struct NEURALA_PUBLIC is_error_condition_enum<neurala::PluginStatus> : true_type
 { };
 } // namespace std
 

--- a/stub/include/neurala/plugin/PluginStatus.h
+++ b/stub/include/neurala/plugin/PluginStatus.h
@@ -66,7 +66,7 @@ NEURALA_PUBLIC std::error_code make_error_code(PluginStatus status) noexcept; //
 namespace std
 {
 template<>
-struct NEURALA_PUBLIC is_error_condition_enum<neurala::PluginStatus> : true_type
+struct is_error_condition_enum<neurala::PluginStatus> : true_type
 { };
 } // namespace std
 

--- a/stub/include/neurala/utils/Options.h
+++ b/stub/include/neurala/utils/Options.h
@@ -40,8 +40,12 @@ public:
 
 private:
 	class Impl;
+	struct ImplDelete
+	{
+		void operator()(Impl*) const;
+	};
 
-	std::unique_ptr<Impl> m_impl;
+	std::unique_ptr<Impl, ImplDelete> m_impl;
 
 public:
 	Options();
@@ -73,15 +77,11 @@ public:
 	/// @copydoc Options(const std::string&,const T&)
 	Options(const std::string& key, const std::string& value);
 
-	Options(const Options&);
-
-	Options(Options&&) noexcept;
-
-	~Options();
-
-	Options& operator=(const Options&);
-
-	Options& operator=(Options&&) noexcept;
+	Options(const Options&) = delete;
+	Options(Options&&) = default;
+	Options& operator=(const Options&) = delete;
+	Options& operator=(Options&&) = default;
+	~Options() = default;
 
 	/**
 	 * @brief Returns if there are no options stored.

--- a/stub/include/neurala/utils/ResultsOutput.h
+++ b/stub/include/neurala/utils/ResultsOutput.h
@@ -32,7 +32,7 @@ namespace neurala
 /**
  * @brief A type representing the status of a pipeline job upon stopping.
  */
-struct ResultsOutputStatus final
+struct NEURALA_PUBLIC ResultsOutputStatus final
 {
 	///< Indicates that the pipeline job has terminated normally.
 	static constexpr ResultsOutputStatus stopped() { return {0}; }

--- a/stub/include/neurala/utils/Version.h
+++ b/stub/include/neurala/utils/Version.h
@@ -117,13 +117,16 @@ public:
 	 *
 	 * If both objects have negative revision values, revision number will not be compared.
 	 */
-	friend constexpr bool operator==(const Version& x, const Version& y) noexcept
+	friend NEURALA_PUBLIC constexpr bool operator==(const Version& x, const Version& y) noexcept
 	{
 		return x.major() == y.major() && x.minor() == y.minor()
 		       && (!x.hasRevision() && !y.hasRevision() ? true : x.revision() == y.revision());
 	}
 
-	friend constexpr bool operator!=(const Version& x, const Version& y) noexcept { return !(x == y); }
+	friend NEURALA_PUBLIC constexpr bool operator!=(const Version& x, const Version& y) noexcept
+	{
+		return !(x == y);
+	}
 
 	/**
 	 * @brief Returns @c true if major, minor, or revision of @p x is less than @p y.
@@ -135,21 +138,27 @@ public:
 	 * 1.1.-1 < 1.1.-5 = false
 	 * 1.1.-1 < 1.1.-5 = false
 	 */
-	friend constexpr bool operator<(const Version& x, const Version& y) noexcept
+	friend NEURALA_PUBLIC constexpr bool operator<(const Version& x, const Version& y) noexcept
 	{
 		return x.major() < y.major() || (x.major() == y.major() && x.minor() < y.minor())
 		       || (x.major() == y.major() && x.minor() == y.minor()
 		           && (!x.hasRevision() && !y.hasRevision() ? false : x.revision() < y.revision()));
 	}
 
-	friend constexpr bool operator<=(const Version& x, const Version& y) noexcept
+	friend NEURALA_PUBLIC constexpr bool operator<=(const Version& x, const Version& y) noexcept
 	{
 		return x == y || x < y;
 	}
 
-	friend constexpr bool operator>(const Version& x, const Version& y) noexcept { return y < x; }
+	friend NEURALA_PUBLIC constexpr bool operator>(const Version& x, const Version& y) noexcept
+	{
+		return y < x;
+	}
 
-	friend constexpr bool operator>=(const Version& x, const Version& y) noexcept { return y <= x; }
+	friend NEURALA_PUBLIC constexpr bool operator>=(const Version& x, const Version& y) noexcept
+	{
+		return y <= x;
+	}
 
 	/// @copydoc Version::operator+=(const Version&)
 	friend NEURALA_PUBLIC Version operator+(Version v1, const Version& v2) noexcept;

--- a/stub/include/neurala/utils/Version.h
+++ b/stub/include/neurala/utils/Version.h
@@ -23,6 +23,8 @@
 #include <ostream>
 #include <string>
 
+#include "neurala/exports.h"
+
 #ifdef __GLIBCXX__
 // Undefine major and minor macros provided by glibc
 #undef major
@@ -37,7 +39,7 @@ namespace neurala
  * Major and minor numbers are required, but revision is optional.  If revision is not set (or is
  * set to a negative number) it will be ignored in comparisons and printing.
  */
-class Version
+class NEURALA_PUBLIC Version
 {
 	std::uint16_t m_major{};
 	std::uint16_t m_minor{};
@@ -105,9 +107,10 @@ public:
 	template<class Archive>
 	void serialize(Archive& archive);
 
-	friend std::ostream& operator<<(std::ostream&, const Version&);
+	friend NEURALA_PUBLIC std::ostream& operator<<(std::ostream&, const Version&);
 
-// NOTE:20210927:jgerity:SWIG does not support `friend constexpr` (https://github.com/swig/swig/issues/2079)
+// NOTE:20210927:jgerity:SWIG does not support `friend constexpr`
+// (https://github.com/swig/swig/issues/2079)
 #ifndef SWIG
 	/**
 	 * @brief Returns @c true if @p x and @p y major, minor, and revision match.
@@ -149,7 +152,7 @@ public:
 	friend constexpr bool operator>=(const Version& x, const Version& y) noexcept { return y <= x; }
 
 	/// @copydoc Version::operator+=(const Version&)
-	friend Version operator+(Version v1, const Version& v2) noexcept;
+	friend NEURALA_PUBLIC Version operator+(Version v1, const Version& v2) noexcept;
 #endif // SWIG
 };
 

--- a/stub/include/neurala/utils/detail/AnyRef.h
+++ b/stub/include/neurala/utils/detail/AnyRef.h
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <typeindex>
 
+#include "neurala/exports.h"
 #include "neurala/meta/detail/demangle.h"
 #include "neurala/meta/detail/typeName.h"
 #include "neurala/utils/string.h"
@@ -35,7 +36,7 @@ namespace neurala
  * It type erases the argument that it stores, but performs type checking at retrieval to avoid
  * incorrect casts at run-time.
  */
-class AnyRef
+class NEURALA_PUBLIC AnyRef
 {
 	enum EQualifier
 	{

--- a/stub/include/neurala/utils/getLine.h
+++ b/stub/include/neurala/utils/getLine.h
@@ -22,6 +22,8 @@
 #include <istream>
 #include <string>
 
+#include "neurala/exports.h"
+
 namespace neurala
 {
 /**
@@ -34,7 +36,7 @@ namespace neurala
  *
  * @return the input @p source
  */
-std::istream& getLine(std::istream& source, std::string& line, char delim);
+NEURALA_PUBLIC std::istream& getLine(std::istream& source, std::string& line, char delim);
 
 /**
  * @brief Reads the contents of @p source until the next end of line character (<tt>"\n"</tt> or
@@ -45,7 +47,7 @@ std::istream& getLine(std::istream& source, std::string& line, char delim);
  *
  * @return the input @p source
  */
-std::istream& getLine(std::istream& source, std::string& line);
+NEURALA_PUBLIC std::istream& getLine(std::istream& source, std::string& line);
 
 } // namespace neurala
 

--- a/stub/include/neurala/utils/string.h
+++ b/stub/include/neurala/utils/string.h
@@ -31,6 +31,7 @@
 #include <utility>
 
 #include "neurala/cppcompat/typetraits.h" // For std17::is_invocable in CUDA code
+#include "neurala/exports.h"
 #include "neurala/utils/getLine.h"
 
 namespace neurala
@@ -40,7 +41,7 @@ namespace detail
 /**
  * @brief Wrapper to allow @c char to be used with @ref stringify().
  */
-class StringifyCharProxy
+class NEURALA_PUBLIC StringifyCharProxy
 {
 private:
 	char m_c;
@@ -56,7 +57,7 @@ public:
 /**
  * @brief Wrapper to allow <tt>const char*</tt> to be used with @ref stringify().
  */
-class StringifyCharPtrProxy
+class NEURALA_PUBLIC StringifyCharPtrProxy
 {
 private:
 	const char* m_s;
@@ -104,7 +105,7 @@ stringify(T&& t) -> decltype(std::forward<T>(t))
 /**
  * @brief Specialization of @ref stringify(T&&) for @c char.
  */
-constexpr StringifyCharProxy
+NEURALA_PUBLIC constexpr StringifyCharProxy
 stringify(char c) noexcept
 {
 	return StringifyCharProxy{c};
@@ -113,7 +114,7 @@ stringify(char c) noexcept
 /**
  * @brief Specialization of @ref stringify(T&&) for <tt>const char*</tt>.
  */
-inline StringifyCharPtrProxy
+NEURALA_PUBLIC inline StringifyCharPtrProxy
 stringify(const char* c) noexcept
 {
 	return StringifyCharPtrProxy{c};
@@ -122,7 +123,7 @@ stringify(const char* c) noexcept
 /**
  * @brief Specialization of @ref stringify(T&&) for <tt>std::istream</tt>.
  */
-inline std::string
+NEURALA_PUBLIC inline std::string
 stringify(std::istream& is) noexcept
 {
 	std::string s;
@@ -221,7 +222,7 @@ toStringWithPrecision(T val, int precision)
  * @brief Converts @p val to a string stripping any trailing zeros, thus "0.9000000" can be returned
  * as "0.9".
  */
-inline std::string
+NEURALA_PUBLIC inline std::string
 toStringRemoveTrailingZeroes(float val)
 {
 	auto str = toString(val);
@@ -236,7 +237,7 @@ toStringRemoveTrailingZeroes(float val)
  * @return 0 if lhs and rhs compare equal, -1 if lhs appears before rhs in lexicographical order,
  * and 1 if lhs appears after rhs in lexicographical order.
  */
-inline int
+NEURALA_PUBLIC inline int
 strcmpCaseInsensitive(const char* lhs, const char* rhs)
 {
 	while (*lhs | *rhs)

--- a/stub/include/neurala/video/CameraDiscoverer.h
+++ b/stub/include/neurala/video/CameraDiscoverer.h
@@ -21,6 +21,7 @@
 
 #include <vector>
 
+#include "neurala/exports.h"
 #include "neurala/video/dto/CameraInfo.h"
 
 namespace neurala

--- a/stub/include/neurala/video/VideoSourceStatus.h
+++ b/stub/include/neurala/video/VideoSourceStatus.h
@@ -30,7 +30,7 @@ namespace neurala
 /**
  * @brief Type that describes the status of a VideoSource
  */
-struct VideoSourceStatus final
+struct NEURALA_PUBLIC VideoSourceStatus final
 {
 	/// Operation was successful.
 	static constexpr VideoSourceStatus success() { return {0}; }
@@ -73,7 +73,7 @@ NEURALA_PUBLIC std::error_condition make_error_condition(VideoSourceStatus res) 
 namespace std
 {
 template<>
-struct is_error_condition_enum<neurala::VideoSourceStatus> : true_type
+struct NEURALA_PUBLIC is_error_condition_enum<neurala::VideoSourceStatus> : true_type
 { };
 } // namespace std
 

--- a/stub/include/neurala/video/VideoSourceStatus.h
+++ b/stub/include/neurala/video/VideoSourceStatus.h
@@ -73,7 +73,7 @@ NEURALA_PUBLIC std::error_condition make_error_condition(VideoSourceStatus res) 
 namespace std
 {
 template<>
-struct NEURALA_PUBLIC is_error_condition_enum<neurala::VideoSourceStatus> : true_type
+struct is_error_condition_enum<neurala::VideoSourceStatus> : true_type
 { };
 } // namespace std
 

--- a/stub/src/Options.cpp
+++ b/stub/src/Options.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <unordered_map>
+#include <utility>
 #include <variant>
 
 #include "neurala/utils/Options.h"
@@ -94,7 +95,13 @@ public:
 	}
 };
 
-Options::Options() : m_impl{std::make_unique<Impl>()} { }
+void
+Options::ImplDelete::operator()(Options::Impl* impl) const
+{
+	delete impl;
+}
+
+Options::Options() : m_impl{new Impl{}} { }
 
 Options::Options(const std::string& name, double value) : Options()
 {
@@ -105,21 +112,6 @@ Options::Options(const std::string& name, const std::string& value) : Options()
 {
 	add(name, value);
 }
-
-Options::Options(const Options& other) : m_impl{std::make_unique<Impl>(*other.m_impl)} { }
-
-Options::Options(Options&&) noexcept = default;
-
-Options::~Options() = default;
-
-Options&
-Options::operator=(const Options& other)
-{
-	m_impl = std::make_unique<Impl>(*(other.m_impl));
-	return *this;
-}
-
-Options& Options::operator=(Options&&) noexcept = default;
 
 bool
 Options::empty() const noexcept


### PR DESCRIPTION
**JIRA**: https://neurala.atlassian.net/browse/SDK-6135

Changelog
------------------

- exported required objects manually using `NEURALA_PUBLIC`

Reviewer Checklist
------------------

> Should be edited by reviewers only

- [ ] Does this implement the story reqs?
- [ ] Does this match the [coding standard](../wiki/C-Based-Languages-Style-Guide)?
	- [ ] Are all TODO's in the [proper format](../wiki/C-Based-Languages-Style-Guide#commenting)?
	- [ ] Have JIRA tickets been made for all TODO's?
- [ ] Does this include tests that exercise the altered/added code?
- [ ] If it modifies a public API, is the documentation updated?