### PR TITLE
Guard template usage unsupported by SWIG

### DIFF
--- a/stub/include/neurala/utils/Options.h
+++ b/stub/include/neurala/utils/Options.h
@@ -50,6 +50,8 @@ private:
 public:
 	Options();
 
+// NOTE:2022-05-16:jgerity:Type trait usage here is unsupported by SWIG
+#ifndef SWIG
 	/**
 	 * @brief Constructs an option that maps key @p key to value @p value.
 	 *
@@ -63,6 +65,7 @@ public:
 	{
 		add(key, std::int64_t(value));
 	}
+#endif // SWIG
 
 	/// @copydoc Options(const std::string&,const T&)
 	template<class T, std::enable_if_t<std::is_same<std::decay_t<T>, bool>::value, bool> = true>


### PR DESCRIPTION
Jira: https://neurala.atlassian.net/browse/SDK-6228

In order to wrap `neurala::Options` for the sake of `neurala::Dataset`, we must guard one of the `Options` constructors to prevent a syntax error in SWIG. `std::is_integral` is mentioned explicitly by the SWIG manual, so I think the fault is either `std::is_same` or `std::decay_t` (I suspect the latter), but we don't need this constructor in the bindings anyway so it's expedient to guard it away.