### PR TITLE
SDK-6415: [1.28.4] Dummy plugin crashes SDKService when Inspection is launched

### DIFF
--- a/plugins/dummy/include/dummy.h
+++ b/plugins/dummy/include/dummy.h
@@ -21,6 +21,7 @@
 
 #include "neurala/plugin/PluginBindings.h"
 
+#include "neurala/utils/ResultsOutput.h"
 #include "neurala/video/CameraDiscoverer.h"
 #include "neurala/video/VideoSource.h"
 #include "neurala/video/VideoSourceStatus.h"
@@ -38,7 +39,7 @@ public:
 	[[nodiscard]] std::vector<dto::CameraInfo> operator()() const noexcept override;
 
 	static void* create(PluginArguments&, PluginErrorCallback&);
-	static void destroy(void* p);
+	static void destroy(void*);
 };
 
 /**
@@ -73,6 +74,15 @@ public:
 
 private:
 	std::unique_ptr<std::uint8_t[]> m_frame;
+};
+
+class PLUGIN_API Output : public ResultsOutput
+{
+public:
+	void operator()(const std::string& metadata, const dto::ImageView* image) noexcept override;
+
+	static void* create(PluginArguments&, PluginErrorCallback&);
+	static void destroy(void*);
 };
 
 } // namespace plug::dummy


### PR DESCRIPTION
**JIRA**: https://neurala.atlassian.net/browse/SDK-6415

Changelog
------------------

- add `ResultsOutput` implementation to dummy plugin

Reviewer Checklist
------------------

> Should be edited by reviewers only

- [ ] Does this implement the story reqs?
- [ ] Does this match the [coding standard](../wiki/C-Based-Languages-Style-Guide)?
	- [ ] Are all TODO's in the [proper format](../wiki/C-Based-Languages-Style-Guide#commenting)?
	- [ ] Have JIRA tickets been made for all TODO's?
- [ ] Does this include tests that exercise the altered/added code?
- [ ] If it modifies a public API, is the documentation updated?