### PR TITLE
SDK-6718: Use 'conancenter' in place of 'conan-center'

### DIFF
--- a/plugins/cms/CMakeLists.txt
+++ b/plugins/cms/CMakeLists.txt
@@ -34,7 +34,7 @@ conan_cmake_install(
     PATH_OR_REFERENCE .
     UPDATE
     REMOTE
-        conan-center
+        conancenter
     BUILD
         missing
     SETTINGS


### PR DESCRIPTION
Jira: https://neurala.atlassian.net/browse/SDK-6718

This PR uses the name `conancenter` instead of `conan-center` for the remote of the same name, to line up with the remote name generated by default.